### PR TITLE
Let kf-render fetch the DJ portraits it renders cards from

### DIFF
--- a/apps/livestream/kf-render/values.yaml
+++ b/apps/livestream/kf-render/values.yaml
@@ -46,7 +46,13 @@ controllers:
           # hosts. Anything else is refused before a socket is opened; combined
           # with the in-code SSRF screen this keeps a service that sits next to
           # the Kubernetes API from being turned into a fetch proxy.
-          KF_ALLOWED_MEDIA_HOSTS: "opus.pro,atoca.house"
+          #
+          # events.kitchenfrequencies.tv serves the DJ portraits that open the
+          # third post of the week, at /d/<key>/portrait. Named exactly rather
+          # than as the apex: matching is by suffix, so "kitchenfrequencies.tv"
+          # would also admit the marketing site and every future subdomain, and
+          # this service has no reason to fetch from any of them.
+          KF_ALLOWED_MEDIA_HOSTS: "opus.pro,atoca.house,events.kitchenfrequencies.tv"
           # MUST stay unset in the cluster. Setting it disables the private-IP
           # SSRF screen; it exists only so the local test suite can serve
           # fixtures from 127.0.0.1.


### PR DESCRIPTION
The third post of the week opens on a two-second black-and-white card built from the artist's photo. That photo now lives on the events site at `/d/<key>/portrait` (shipped today), and `kf-render` screens every media fetch against a host allowlist — so as things stand the card fails with a blocked-host error instead of rendering.

```
- KF_ALLOWED_MEDIA_HOSTS: "opus.pro,atoca.house"
+ KF_ALLOWED_MEDIA_HOSTS: "opus.pro,atoca.house,events.kitchenfrequencies.tv"
```

**Named as the exact subdomain, not the apex.** Matching in `_screen_url()` is `host == a or host.endswith("." + a)`, so `kitchenfrequencies.tv` would also admit the marketing site and every future subdomain. This service has no reason to fetch from any of them.

The in-code SSRF screen is unchanged and still runs after this check — the allowlist decides *which* hosts, the screen still rejects loopback, link-local (including the cloud metadata endpoint), private and reserved ranges after resolution. `KF_ALLOW_PRIVATE_MEDIA` stays unset, as its own comment requires.

Portraits are stored in colour; the greyscale and the push-in happen in the render service.

Tracked as #47 in the Kitchen Frequencies board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JvFzesZCUwbhWtq2uE9JWY